### PR TITLE
Fix insights-client --unregister

### DIFF
--- a/manifests/core_host_inventory.pp
+++ b/manifests/core_host_inventory.pp
@@ -191,7 +191,7 @@ class iop::core_host_inventory (
           "INVENTORY_DB_NAME=${database_name}",
           "INVENTORY_DB_USER=${database_user}",
           "INVENTORY_DB_PASS=${database_password}",
-          'KAFKA_BOOTSTRAP_SERVERS=PLAINTEXT://iop-core-kafka:9092',
+          'KAFKA_BOOTSTRAP_SERVERS=iop-core-kafka:9092',
           'LISTEN_PORT=8081',
           'BYPASS_RBAC=true',
           'FF_LAST_CHECKIN=true',

--- a/manifests/service_advisor.pp
+++ b/manifests/service_advisor.pp
@@ -98,6 +98,7 @@ class iop::service_advisor (
           "ADVISOR_DB_USER=${database_user}",
           "ADVISOR_DB_PASSWORD=${database_password}",
           'ALLOWED_HOSTS=*',
+          'INVENTORY_SERVER_URL=http://iop-core-host-inventory-api:8081/api/inventory/v1',
         ],
       },
       'Install'   => { 'WantedBy' => 'default.target' },


### PR DESCRIPTION
This fixes the link between insights-client -> advisor -> inventory -> kafka  that is needed to delete hosts.