### PR TITLE
Support authenticated registry

### DIFF
--- a/manifests/core_engine.pp
+++ b/manifests/core_engine.pp
@@ -60,7 +60,8 @@ class iop::core_engine (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => 'default.target',

--- a/manifests/core_gateway.pp
+++ b/manifests/core_gateway.pp
@@ -102,7 +102,8 @@ class iop::core_gateway (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => [

--- a/manifests/core_host_inventory.pp
+++ b/manifests/core_host_inventory.pp
@@ -213,7 +213,8 @@ class iop::core_host_inventory (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => ['multi-user.target', 'default.target'],
@@ -260,7 +261,8 @@ class iop::core_host_inventory (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => ['multi-user.target', 'default.target'],

--- a/manifests/core_ingress.pp
+++ b/manifests/core_ingress.pp
@@ -21,7 +21,9 @@ class iop::core_ingress (
     quadlet_type => 'container',
     user         => 'root',
     defaults     => {},
-    require      => Podman::Network['iop-core-network'],
+    require      => [
+      Podman::Network['iop-core-network'],
+    ],
     settings     => {
       'Unit'      => {
         'Description' => 'IOP Core Ingress Container',
@@ -41,7 +43,8 @@ class iop::core_ingress (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => 'default.target',

--- a/manifests/core_kafka.pp
+++ b/manifests/core_kafka.pp
@@ -41,7 +41,7 @@ class iop::core_kafka (
     defaults     => {},
     require      => [
       Podman::Volume['iop-core-kafka-data'],
-      Podman::Network['iop-core-network']
+      Podman::Network['iop-core-network'],
     ],
     settings     => {
       'Unit'      => {
@@ -66,7 +66,8 @@ class iop::core_kafka (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => ['multi-user.target', 'default.target'],

--- a/manifests/core_puptoo.pp
+++ b/manifests/core_puptoo.pp
@@ -20,7 +20,9 @@ class iop::core_puptoo (
     quadlet_type => 'container',
     user         => 'root',
     defaults     => {},
-    require      => Podman::Network['iop-core-network'],
+    require      => [
+      Podman::Network['iop-core-network'],
+    ],
     settings     => {
       'Unit'      => {
         'Description' => 'IOP Core Puptoo Container',
@@ -36,7 +38,8 @@ class iop::core_puptoo (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => 'default.target',

--- a/manifests/core_yuptoo.pp
+++ b/manifests/core_yuptoo.pp
@@ -20,7 +20,9 @@ class iop::core_yuptoo (
     quadlet_type => 'container',
     user         => 'root',
     defaults     => {},
-    require      => Podman::Network['iop-core-network'],
+    require      => [
+      Podman::Network['iop-core-network'],
+    ],
     settings     => {
       'Unit'      => {
         'Description' => 'IOP Core Yuptoo Container',
@@ -36,7 +38,8 @@ class iop::core_yuptoo (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => 'default.target',

--- a/manifests/service_advisor.pp
+++ b/manifests/service_advisor.pp
@@ -150,7 +150,8 @@ class iop::service_advisor (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },
@@ -193,7 +194,8 @@ class iop::service_advisor (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },

--- a/manifests/service_remediations.pp
+++ b/manifests/service_remediations.pp
@@ -127,7 +127,8 @@ class iop::service_remediations (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },

--- a/manifests/service_vmaas.pp
+++ b/manifests/service_vmaas.pp
@@ -149,7 +149,8 @@ class iop::service_vmaas (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => ['multi-user.target', 'default.target'],
@@ -198,7 +199,8 @@ class iop::service_vmaas (
         'Volume'        => $socket_volume,
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => {
         'WantedBy' => ['multi-user.target', 'default.target'],

--- a/manifests/service_vulnerability.pp
+++ b/manifests/service_vulnerability.pp
@@ -189,7 +189,8 @@ class iop::service_vulnerability (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },
@@ -235,7 +236,8 @@ class iop::service_vulnerability (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },
@@ -285,7 +287,8 @@ class iop::service_vulnerability (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },
@@ -336,7 +339,8 @@ class iop::service_vulnerability (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },
@@ -387,7 +391,8 @@ class iop::service_vulnerability (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },
@@ -438,7 +443,8 @@ class iop::service_vulnerability (
         ],
       },
       'Service'   => {
-        'Restart' => 'on-failure',
+        'Environment' => 'REGISTRY_AUTH_FILE=/etc/foreman/registry-auth.json',
+        'Restart'     => 'on-failure',
       },
       'Install'   => { 'WantedBy' => 'default.target' },
     },


### PR DESCRIPTION
Supports authenitcated registries through a single auth file that the user will need to point to during podman login. Each quadlet will then inherit the location of that auth file enabling it to pull authenticated registry images.

This allows users with authenticated registries to use:

```
podman login <registry> --auth-file /etc/foreman/registry-auth.json
```